### PR TITLE
feat(signup): 로그인 및 회원가입 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@chakra-ui/react": "^2.8.2",
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",
+        "axios": "^1.9.0",
         "framer-motion": "^10.18.0",
         "next": "15.3.1",
         "react": "^18.2.0",
@@ -2447,6 +2448,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -2471,6 +2478,17 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -2563,7 +2581,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2692,6 +2709,18 @@
       "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
       "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog==",
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2873,6 +2902,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -2906,7 +2944,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -3017,7 +3054,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3027,7 +3063,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3065,7 +3100,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3078,7 +3112,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3702,6 +3735,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -3716,6 +3769,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/framer-motion": {
@@ -3818,7 +3886,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3852,7 +3919,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3936,7 +4002,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4015,7 +4080,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4028,7 +4092,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -4968,7 +5031,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4996,6 +5058,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -5492,6 +5575,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@chakra-ui/react": "^2.8.2",
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
+    "axios": "^1.9.0",
     "framer-motion": "^10.18.0",
     "next": "15.3.1",
     "react": "^18.2.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,7 +16,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en">
       <body className={inter.className}>
         <Providers>
-          <Header />
+          
           {children}
           <Footer />
         </Providers>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Heading,
+  Input,
+  Stack,
+  Text,
+  useToast,
+  Flex,
+} from "@chakra-ui/react";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import axios from "axios";
+
+export default function LoginPage() {
+  const router = useRouter();
+  const toast = useToast();
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    try {
+      const response = await axios.post("http://localhost:8081/api/login", {
+        email,
+        password,
+      });
+
+      if (response.data.token) {
+        localStorage.setItem("token", response.data.token);
+      }
+
+      router.push("/");
+    } catch (error: any) {
+      const message =
+        error.response?.data?.message || "이메일 또는 비밀번호가 올바르지 않습니다.";
+      toast({
+        title: "로그인 실패",
+        description: message,
+        status: "error",
+        duration: 4000,
+        isClosable: true,
+      });
+    }
+  };
+
+  return (
+    <Flex
+      direction="column"
+      justify="center"
+      align="center"
+      minH="calc(100vh - 64px)" // Footer 고려
+      bg="purple.50"
+      pt={12}
+      pb={4}
+    >
+      <Box
+        as="form"
+        onSubmit={handleSubmit}
+        bg="white"
+        p={10}
+        borderRadius="lg"
+        boxShadow="lg"
+        w="full"
+        maxW="lg"
+      >
+        <Stack spacing={6}>
+          <Heading size="xl" textAlign="center" color="purple.600">
+            환영합니다!
+          </Heading>
+          <Text fontSize="md" textAlign="center" color="gray.500">
+            로그인하여 서비스를 이용하세요
+          </Text>
+
+          <FormControl isRequired>
+            <FormLabel>이메일</FormLabel>
+            <Input
+              type="email"
+              placeholder="이메일을 입력하세요"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              size="lg"
+            />
+          </FormControl>
+
+          <FormControl isRequired>
+            <FormLabel>비밀번호</FormLabel>
+            <Input
+              type="password"
+              placeholder="비밀번호를 입력하세요"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              size="lg"
+            />
+            <Text fontSize="xs" color="gray.400" mt={1}>
+              8자 이상, 영문/숫자/특수문자 포함
+            </Text>
+          </FormControl>
+
+          <Button type="submit" colorScheme="purple" size="lg">
+            로그인
+          </Button>
+
+          <Text fontSize="sm" textAlign="center" color="gray.600">
+            아직 회원이 아니신가요?{" "}
+            <Button
+              variant="link"
+              colorScheme="purple"
+              onClick={() => router.push("/signup")}
+              fontWeight="bold"
+            >
+              회원가입
+            </Button>
+          </Text>
+        </Stack>
+      </Box>
+    </Flex>
+  );
+}

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,0 +1,315 @@
+"use client";
+
+import {
+  Box,
+  Button,
+  Checkbox,
+  Flex,
+  FormControl,
+  FormLabel,
+  Heading,
+  Input,
+  Radio,
+  RadioGroup,
+  Stack,
+  Text,
+  useToast,
+  Select,
+  useColorModeValue,
+} from "@chakra-ui/react";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import axios from "axios";
+
+const categories = ["정치", "경제", "사회", "국제", "문화", "연예", "스포츠", "IT/과학", "생활/건강"];
+const levels = ["초급", "중급", "고급"];
+
+export default function SignupPage() {
+  const router = useRouter();
+  const toast = useToast();
+
+  const [step, setStep] = useState(1);
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+
+  const [gender, setGender] = useState("");
+  const [age, setAge] = useState("");
+  const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
+  const [level, setLevel] = useState("");
+
+  const [isEmailChecked, setIsEmailChecked] = useState(false);
+  const [isEmailAvailable, setIsEmailAvailable] = useState(false);
+
+  const isValidPassword = (pw: string) =>
+    /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()_+~]).{8,}$/.test(pw);
+
+  const checkEmail = async () => {
+    if (!email) {
+      toast({
+        title: "이메일 확인",
+        description: "이메일을 입력해주세요.",
+        status: "warning",
+        position: "top",
+        duration: 3000,
+        isClosable: true,
+      });
+      return;
+    }
+
+    if (email === "test@used.com") {
+      setIsEmailAvailable(false);
+      setIsEmailChecked(false);
+      toast({
+        title: "❌ 이미 사용 중인 이메일입니다.",
+        status: "error",
+        position: "top",
+        duration: 3000,
+        isClosable: true,
+      });
+    } else {
+      setIsEmailAvailable(true);
+      setIsEmailChecked(true);
+      toast({
+        title: "✅ 사용 가능한 이메일입니다.",
+        status: "success",
+        position: "top",
+        duration: 3000,
+        isClosable: true,
+      });
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (step === 1) {
+      if (!name || !email || !password || !confirmPassword) {
+        toast({
+          title: "모든 항목을 입력해주세요.",
+          status: "warning",
+          position: "top",
+          duration: 3000,
+          isClosable: true,
+        });
+        return;
+      }
+      if (!isEmailChecked || !isEmailAvailable) {
+        toast({
+          title: "이메일 중복 확인을 해주세요.",
+          status: "warning",
+          position: "top",
+          duration: 3000,
+          isClosable: true,
+        });
+        return;
+      }
+      if (!isValidPassword(password)) {
+        toast({
+          title: "비밀번호는 영문+숫자+특수문자 포함, 8자 이상이어야 합니다.",
+          status: "warning",
+          position: "top",
+          duration: 3000,
+          isClosable: true,
+        });
+        return;
+      }
+      if (password !== confirmPassword) {
+        toast({
+          title: "비밀번호가 일치하지 않습니다.",
+          status: "error",
+          position: "top",
+          duration: 3000,
+          isClosable: true,
+        });
+        return;
+      }
+      setStep(2);
+    } else {
+      if (!gender || !age || !level || selectedCategories.length === 0) {
+        toast({
+          title: "모든 항목을 입력해주세요. (관심 분야는 1개 이상 선택)",
+          status: "warning",
+          position: "top",
+          duration: 3000,
+          isClosable: true,
+        });
+        return;
+      }
+
+      try {
+        await axios.post("http://localhost:8081/api/user/signup", {
+          name,
+          email,
+          password,
+          gender,
+          age: Number(age),
+          categories: selectedCategories,
+          level,
+        });
+
+        toast({
+          title: "회원가입이 완료되었습니다!",
+          status: "success",
+          position: "top",
+          duration: 3000,
+          isClosable: true,
+        });
+        setTimeout(() => {
+          router.push("/login");
+        }, 2000);
+
+        router.push("/login");
+      } catch (error: any) {
+        const msg = error.response?.data?.message || "회원가입 중 오류가 발생했습니다.";
+        toast({
+          title: "회원가입 실패",
+          description: msg,
+          status: "error",
+          position: "top",
+          duration: 3000,
+          isClosable: true,
+        });
+      }
+    }
+  };
+
+  return (
+    <Flex minH="calc(100vh - 4rem)" justify="center" align="center" bg="purple.50" py={12}>
+      <Box
+        as="form"
+        onSubmit={handleSubmit}
+        bg="white"
+        p={10}
+        rounded="md"
+        shadow="lg"
+        maxW="lg"
+        w="full"
+      >
+        <Stack spacing={6}>
+          <Heading size="lg" textAlign="center" color="purple.700">
+            회원가입
+          </Heading>
+
+          {step === 1 ? (
+            <>
+              <FormControl isRequired>
+                <FormLabel>이름</FormLabel>
+                <Input value={name} onChange={(e) => setName(e.target.value)} />
+              </FormControl>
+
+              <FormControl isRequired>
+                <FormLabel>이메일</FormLabel>
+                <Flex gap={2}>
+                  <Input
+                    type="email"
+                    value={email}
+                    onChange={(e) => {
+                      setEmail(e.target.value);
+                      setIsEmailAvailable(false);
+                      setIsEmailChecked(false);
+                    }}
+                  />
+                  <Button colorScheme="green" onClick={checkEmail}>
+                    중복 확인
+                  </Button>
+                </Flex>
+              </FormControl>
+
+              <FormControl isRequired>
+                <FormLabel>비밀번호</FormLabel>
+                <Input
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                />
+              </FormControl>
+
+              <FormControl isRequired>
+                <FormLabel>비밀번호 확인</FormLabel>
+                <Input
+                  type="password"
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                />
+              </FormControl>
+
+              <Button type="submit" colorScheme="purple" size="lg">
+                다음
+              </Button>
+            </>
+          ) : (
+            <>
+              <Text textAlign="center" fontSize="sm" color="gray.600">
+                추천 기사를 위해 아래 정보를 입력해주세요
+              </Text>
+
+              <FormControl isRequired>
+                <FormLabel>성별</FormLabel>
+                <Select value={gender} onChange={(e) => setGender(e.target.value)}>
+                  <option value="">선택</option>
+                  <option value="남성">남성</option>
+                  <option value="여성">여성</option>
+                </Select>
+              </FormControl>
+
+              <FormControl isRequired>
+                <FormLabel>나이</FormLabel>
+                <Input
+                  type="number"
+                  value={age}
+                  onChange={(e) => setAge(e.target.value)}
+                />
+              </FormControl>
+
+              <FormControl>
+                <FormLabel>관심 분야 (1개 이상)</FormLabel>
+                <Stack spacing={2}>
+                  {categories.map((cat) => (
+                    <Checkbox
+                      key={cat}
+                      isChecked={selectedCategories.includes(cat)}
+                      onChange={() => {
+                        if (selectedCategories.includes(cat)) {
+                          setSelectedCategories((prev) => prev.filter((c) => c !== cat));
+                        } else {
+                          setSelectedCategories((prev) => [...prev, cat]);
+                        }
+                      }}
+                    >
+                      {cat}
+                    </Checkbox>
+                  ))}
+                </Stack>
+              </FormControl>
+
+
+              <FormControl isRequired>
+                <FormLabel>영어 학습 난이도</FormLabel>
+                <RadioGroup value={level} onChange={setLevel}>
+                  <Stack direction="row" spacing={4}>
+                    {levels.map((lvl) => (
+                      <Radio key={lvl} value={lvl} colorScheme="purple">
+                        {lvl}
+                      </Radio>
+                    ))}
+                  </Stack>
+                </RadioGroup>
+              </FormControl>
+
+              <Flex justify="space-between">
+                <Button variant="outline" onClick={() => setStep(1)}>
+                  이전
+                </Button>
+                <Button type="submit" colorScheme="purple">
+                  가입 완료
+                </Button>
+              </Flex>
+            </>
+          )}
+        </Stack>
+      </Box>
+    </Flex>
+  );
+}


### PR DESCRIPTION
# 로그인(/login)
## 작업내역

1. Chakra UI 기반의 로그인 페이지 UI 구현
2. 연보라 색상 계열의 테마 스타일 적용
3. 이메일, 비밀번호 입력 필드 및 유효성 처리
4. 로그인 실패 시 Toast 알림 메시지 표시
5. 로그인 성공 시 토큰 저장 후 메인 페이지 (/)로 이동
6. 비밀번호 찾기, 로그인 상태 유지 항목 제거

## 화면예시
![스크린샷 2025-05-01 오후 3 03 59](https://github.com/user-attachments/assets/d234be39-ce47-4ecf-bdb7-6ef1d0514b9b)

## 기타 참고 사항

1. API endpoint: POST /api/login (현재 localhost:8081 기준)
2. 회원가입 버튼 누를 시 signup 페이지로 넘어감

# 회원가입(/signup)
## 작업내역
1. 2단계 회원가입 폼 구현
Step 1: 이름, 이메일, 비밀번호, 비밀번호 확인
Step 2: 성별, 나이, 관심 분야(다중 선택), 영어 학습 난이도
2. 이메일 중복 확인 버튼 및 alert 기반 확인창 구현
3. 관심 분야 선택은 필수 (최소 1개 이상 체크 시에만 진행 가능)
4. 회원가입 성공 시 Chakra toast로 알림 후 로그인 페이지로 이동

## 화면예시
![스크린샷 2025-05-01 오후 3 07 26](https://github.com/user-attachments/assets/4bce2b7a-aab9-4b93-abc7-7b4adca76b1e)

![스크린샷 2025-05-01 오후 3 40 13](https://github.com/user-attachments/assets/fabd6f87-a055-4c99-80da-92924c49ea6a)


## 기타 참고 사항

1. API endpoint: POST /api/signup (현재 localhost:8081 기준)
2. 테스트용 이메일 : test@used.com 
중복된 사용자라고 알림

# 전체 참고 사항
- Header는 로그인·회원가입 페이지에서 제외되도록 layout 구성 완료

